### PR TITLE
Fix file ownership and permissions to enable edition by default user

### DIFF
--- a/roles/install/handlers/main.yml
+++ b/roles/install/handlers/main.yml
@@ -13,3 +13,12 @@
   service:
     name: 'incron'
     state: 'restarted'
+
+- name: restart web services
+  systemd:
+    name: '{{ item }}'
+    state: 'restarted'
+    daemon_reload: 'yes'
+  with_items:
+    - 'nginx'
+    - 'php7.3-fpm'

--- a/roles/install/tasks/system.yml
+++ b/roles/install/tasks/system.yml
@@ -28,3 +28,20 @@
     src: 'etc/nodogsplash/htdocs'
     dest: '/etc/nodogsplash'
     mode: 0644
+
+- name: set umask for nginx and php-fpm services
+  lineinfile:
+    path: '{{ item }}'
+    line: 'UMask=0002'
+    insertafter: '^\[Service\].*'
+  with_items:
+    - '/lib/systemd/system/nginx.service'
+    - '/lib/systemd/system/php7.3-fpm.service'
+  notify: restart web services
+
+- name: set group for php-fpm process
+  lineinfile:
+    path: '/etc/php/7.3/fpm/pool.d/www.conf'
+    regexp: '^group\s*=\s*www-data.*'
+    line: 'group = {{ moodlebox_username }}'
+  notify: restart web services

--- a/roles/moodle/tasks/coreinstall.yml
+++ b/roles/moodle/tasks/coreinstall.yml
@@ -85,11 +85,12 @@
     chdir: '{{ moodlebox_moodle_source_dir }}'
     creates: '{{ moodlebox_moodle_source_dir }}/config.php'
 
-- name: change Moodle config file owner and group
+- name: set Moodle config file owner, group and permissions
   file:
     path: '{{ moodlebox_moodle_source_dir }}/config.php'
     owner: 'www-data'
     group: '{{ moodlebox_username }}'
+    mode: 'ug+w,o-w'
 
 - name: write extra parameters to the Moodle config file
   lineinfile:

--- a/roles/moodle/tasks/coreinstall.yml
+++ b/roles/moodle/tasks/coreinstall.yml
@@ -11,8 +11,8 @@
   file:
     path: '{{ item }}'
     state: 'directory'
-    owner: '{{ moodlebox_username }}'
-    group: 'www-data'
+    owner: 'www-data'
+    group: '{{ moodlebox_username }}'
     mode: 'ug+w,o-w'
     recurse: 'yes'
   with_items:
@@ -88,8 +88,8 @@
 - name: change Moodle config file owner and group
   file:
     path: '{{ moodlebox_moodle_source_dir }}/config.php'
-    owner: '{{ moodlebox_username }}'
-    group: 'www-data'
+    owner: 'www-data'
+    group: '{{ moodlebox_username }}'
 
 - name: write extra parameters to the Moodle config file
   lineinfile:

--- a/roles/moodle/tasks/main.yml
+++ b/roles/moodle/tasks/main.yml
@@ -52,8 +52,8 @@
   get_url:
     url: 'https://www.adminer.org/latest.php'
     dest: '{{ moodlebox_moodle_source_dir }}/adminer.php'
-    owner: '{{ moodlebox_username }}'
-    group: 'www-data'
+    owner: 'www-data'
+    group: '{{ moodlebox_username }}'
     mode: '0664'
 
 - name: copy root CA certificate

--- a/roles/moodle/tasks/mathjax.yml
+++ b/roles/moodle/tasks/mathjax.yml
@@ -11,7 +11,7 @@
   file:
     path: '{{ moodlebox_moodle_source_dir }}/lib/MathJax'
     state: 'directory'
-    owner: '{{ moodlebox_username }}'
-    group: 'www-data'
+    owner: 'www-data'
+    group: '{{ moodlebox_username }}'
     mode: 'ug+w,o-w'
     recurse: 'yes'

--- a/roles/moodle/tasks/upgrade.yml
+++ b/roles/moodle/tasks/upgrade.yml
@@ -27,8 +27,8 @@
   file:
     path: '{{ item }}'
     state: 'directory'
-    owner: '{{ moodlebox_username }}'
-    group: 'www-data'
+    owner: 'www-data'
+    group: '{{ moodlebox_username }}'
     mode: 'ug+w,o-w'
     recurse: 'yes'
   with_items:


### PR DESCRIPTION
Fixes issue #165.

- Moodle files owner/group changed to more logical `www-data:moodlebox`
- Umask of nginx and php-fpm set to `0002` instead of `0022`to enable group edition
- Moodle config file permissions fixed